### PR TITLE
fix(chroma-sort): Hotfix 320px overflow + text contrast

### DIFF
--- a/apps/web-astro/public/games/chroma-sort/styles.css
+++ b/apps/web-astro/public/games/chroma-sort/styles.css
@@ -12,7 +12,7 @@
   --cs-surface-hover: rgba(255,255,255,0.10);
   --cs-border: rgba(255,255,255,0.12);
   --cs-text: #E8E6F0;
-  --cs-text-dim: rgba(232,230,240,0.6);
+  --cs-text-dim: rgba(232,230,240,0.75);
   --cs-text-bright: #FFFFFF;
   --cs-tube-bg: rgba(255,255,255,0.08);
   --cs-tube-border: rgba(255,255,255,0.18);
@@ -465,12 +465,12 @@
 }
 
 .cs-action-label {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--cs-text-dim);
 }
 
 .cs-action-badge {
-  font-size: 10px;
+  font-size: 11px;
   color: var(--cs-accent);
   font-weight: 600;
 }
@@ -757,6 +757,23 @@
     --cs-tube-width: 46px;
     --cs-ball-size: 44px;
     --cs-tube-gap: 6px;
+  }
+}
+
+/* Small + short screens: prevent Hard mode (11 tubes) from overflowing */
+@media (max-width: 380px) and (max-height: 700px) {
+  :root {
+    --cs-tube-width: 38px;
+    --cs-ball-size: 36px;
+    --cs-tube-gap: 4px;
+  }
+  .cs-tube {
+    min-height: calc(var(--cs-ball-size) * 4 + 16px);
+    border-radius: 0 0 16px 16px;
+  }
+  .cs-action-bar {
+    gap: 8px;
+    padding: 6px 0;
   }
 }
 

--- a/apps/web-astro/public/sw.js
+++ b/apps/web-astro/public/sw.js
@@ -58,7 +58,7 @@ self.addEventListener('notificationclick', (event) => {
 });
 
 // Cache version - increment this on each deployment
-const CACHE_VERSION = 73;
+const CACHE_VERSION = 74;
 const CACHE_NAME = `weekly-arcade-v${CACHE_VERSION}`;
 
 // Core assets to pre-cache


### PR DESCRIPTION
## Summary
Post-launch hotfix from Visual QA (25 screenshots captured).

- CRITICAL: Hard mode (11 tubes) overflows viewport at 320px, hiding action bar
- HIGH: Text contrast below WCAG AA (dim text opacity 0.6)
- MEDIUM: Action labels too small (11px/10px)

## Changes
- Add responsive breakpoint for small+short viewports (<=380px AND <=700px)
- Raise --cs-text-dim opacity 0.6 -> 0.75
- Bump action label/badge font sizes
- CACHE_VERSION 73 -> 74

## Test plan
- [ ] Load Hard mode at 320x568 viewport — action bar visible
- [ ] Text readable on all screens
- [ ] Build passes

Generated with [Claude Code](https://claude.com/claude-code)