### PR TITLE
fix(chroma-sort): Mobile UX — touch, safe areas, feedback

### DIFF
--- a/apps/web-astro/public/games/chroma-sort/game.js
+++ b/apps/web-astro/public/games/chroma-sort/game.js
@@ -1617,6 +1617,14 @@
     initAuth();
     initHeader();
 
+    // Mobile UX: prevent context menu on long-press (tubes, balls)
+    app.addEventListener('contextmenu', function (e) { e.preventDefault(); });
+
+    // Mobile UX: prevent pull-to-refresh during gameplay
+    app.addEventListener('touchmove', function (e) {
+      if (state.screen === 'puzzle') e.preventDefault();
+    }, { passive: false });
+
     // Always start at home screen per PRD flow
     // Tutorial triggers when user taps Endless Mode for the first time
     renderHome();

--- a/apps/web-astro/public/games/chroma-sort/styles.css
+++ b/apps/web-astro/public/games/chroma-sort/styles.css
@@ -40,7 +40,9 @@
   width: 100%;
   max-width: 600px;
   margin: 0 auto;
-  padding: 0 12px 24px;
+  padding: 0 12px calc(24px + env(safe-area-inset-bottom, 0px));
+  padding-left: calc(12px + env(safe-area-inset-left, 0px));
+  padding-right: calc(12px + env(safe-area-inset-right, 0px));
   min-height: calc(100dvh - 60px);
   display: flex;
   flex-direction: column;
@@ -48,6 +50,7 @@
   color: var(--cs-text);
   -webkit-tap-highlight-color: transparent;
   user-select: none;
+  touch-action: manipulation;
 }
 
 /* ---- Home Screen ---- */
@@ -316,6 +319,8 @@
   transition: transform var(--cs-transition), box-shadow var(--cs-transition), border-color var(--cs-transition);
   outline: none;
   gap: 2px;
+  touch-action: manipulation;
+  -webkit-touch-callout: none;
 }
 
 .cs-tube::before {
@@ -332,6 +337,11 @@
 
 .cs-tube:hover {
   border-color: rgba(255,255,255,0.25);
+}
+
+.cs-tube:active {
+  transform: scale(0.96);
+  opacity: 0.85;
 }
 
 .cs-tube:focus-visible {

--- a/apps/web-astro/public/sw.js
+++ b/apps/web-astro/public/sw.js
@@ -58,7 +58,7 @@ self.addEventListener('notificationclick', (event) => {
 });
 
 // Cache version - increment this on each deployment
-const CACHE_VERSION = 74;
+const CACHE_VERSION = 75;
 const CACHE_NAME = `weekly-arcade-v${CACHE_VERSION}`;
 
 // Core assets to pre-cache


### PR DESCRIPTION
## Summary
Mobile UX hardening based on mobile-game-ux audit principles.

### Changes
- `touch-action: manipulation` on app + tubes (prevents double-tap zoom)
- `-webkit-touch-callout: none` on tubes (prevents iOS long-press callout)
- Safe area inset padding via `env(safe-area-inset-*)` (notch/Dynamic Island)
- Context menu prevention during gameplay
- Pull-to-refresh prevention during puzzle screen
- `:active` visual feedback on tubes (scale 0.96 + opacity 0.85)
- CACHE_VERSION 74 -> 75

## Test plan
- [ ] No double-tap zoom when rapidly tapping tubes on iOS/Android
- [ ] No context menu on long-press on tubes
- [ ] No pull-to-refresh during puzzle (scroll OK on home screen)
- [ ] Tube press gives immediate scale feedback
- [ ] Game respects notch safe areas on iPhone 14+
- [ ] Build passes

Generated with [Claude Code](https://claude.com/claude-code)