### PR TITLE
fix(chroma-sort): Rewrite audio engine — master gain, iOS, ADSR

### DIFF
--- a/apps/web-astro/public/games/chroma-sort/game.js
+++ b/apps/web-astro/public/games/chroma-sort/game.js
@@ -212,63 +212,131 @@
 
   var audio = {
     ctx: null,
+    masterGain: null,
     enabled: true,
+    volume: 0.3,
 
     init: function () {
       if (this.ctx) return;
       try {
         this.ctx = new (window.AudioContext || window.webkitAudioContext)();
+        this.masterGain = this.ctx.createGain();
+        this.masterGain.connect(this.ctx.destination);
+        this.masterGain.gain.value = this.volume;
+        // iOS requires explicit resume after user gesture
+        if (this.ctx.state === 'suspended') {
+          this.ctx.resume();
+        }
       } catch (e) { /* no audio support */ }
     },
 
-    playTone: function (freq, duration, type, gain) {
-      if (!this.ctx || !this.enabled) return;
+    setVolume: function (v) {
+      this.volume = Math.max(0, Math.min(1, v));
+      if (this.masterGain) {
+        this.masterGain.gain.value = this.enabled ? this.volume : 0;
+      }
+    },
+
+    // Play a tone at a specific time offset using AudioContext scheduling
+    // (no setTimeout — precise timing, works in background tabs)
+    playTone: function (freq, duration, type, gain, startOffset) {
+      if (!this.ctx || !this.enabled || !this.masterGain) return;
       type = type || 'sine';
       gain = gain !== undefined ? gain : 0.3;
+      startOffset = startOffset || 0;
       try {
+        var now = this.ctx.currentTime + startOffset;
         var osc = this.ctx.createOscillator();
         var g = this.ctx.createGain();
         osc.connect(g);
-        g.connect(this.ctx.destination);
+        g.connect(this.masterGain);
         osc.type = type;
-        osc.frequency.setValueAtTime(freq, this.ctx.currentTime);
-        g.gain.setValueAtTime(0, this.ctx.currentTime);
-        g.gain.linearRampToValueAtTime(gain, this.ctx.currentTime + 0.01);
-        g.gain.exponentialRampToValueAtTime(0.001, this.ctx.currentTime + duration);
-        osc.start(this.ctx.currentTime);
-        osc.stop(this.ctx.currentTime + duration + 0.05);
+        osc.frequency.setValueAtTime(freq, now);
+        // ADSR: quick attack (5ms), sustain, exponential release
+        g.gain.setValueAtTime(0, now);
+        g.gain.linearRampToValueAtTime(gain * 1.2, now + 0.005); // attack peak
+        g.gain.linearRampToValueAtTime(gain, now + 0.015);        // settle to sustain
+        g.gain.exponentialRampToValueAtTime(0.001, now + duration);
+        osc.start(now);
+        osc.stop(now + duration + 0.05);
       } catch (e) { /* ignore */ }
     },
 
-    pickup: function () { this.playTone(880, 0.08, 'sine', 0.3); },
-    place: function () {
-      this.playTone(660, 0.06, 'sine', 0.35);
-      setTimeout(function () { audio.playTone(440, 0.08, 'sine', 0.25); }, 30);
+    // Play a frequency ramp (single tone that slides)
+    playRamp: function (freqStart, freqEnd, duration, type, gain, startOffset) {
+      if (!this.ctx || !this.enabled || !this.masterGain) return;
+      type = type || 'sine';
+      gain = gain !== undefined ? gain : 0.3;
+      startOffset = startOffset || 0;
+      try {
+        var now = this.ctx.currentTime + startOffset;
+        var osc = this.ctx.createOscillator();
+        var g = this.ctx.createGain();
+        osc.connect(g);
+        g.connect(this.masterGain);
+        osc.type = type;
+        osc.frequency.setValueAtTime(freqStart, now);
+        osc.frequency.linearRampToValueAtTime(freqEnd, now + duration * 0.7);
+        g.gain.setValueAtTime(0, now);
+        g.gain.linearRampToValueAtTime(gain, now + 0.005);
+        g.gain.exponentialRampToValueAtTime(0.001, now + duration);
+        osc.start(now);
+        osc.stop(now + duration + 0.05);
+      } catch (e) { /* ignore */ }
     },
-    invalid: function () { this.playTone(200, 0.12, 'square', 0.15); },
+
+    // --- Sound Events ---
+
+    pickup: function () {
+      this.playTone(880, 0.08, 'sine', 0.25);
+    },
+
+    place: function () {
+      // Two-tone thud: 660Hz → 440Hz with ADSR peak for satisfying feel
+      this.playTone(660, 0.07, 'sine', 0.3, 0);
+      this.playTone(440, 0.09, 'sine', 0.2, 0.03);
+    },
+
+    invalid: function () {
+      this.playTone(200, 0.12, 'square', 0.12);
+    },
+
     stackTransfer: function (count) {
+      // Descending cascade — one tone per ball, AudioContext-scheduled
       var freqs = [660, 550, 440, 370];
-      for (var i = 0; i < Math.min(count, 4); i++) {
-        (function (idx) {
-          setTimeout(function () { audio.playTone(freqs[idx], 0.06, 'sine', 0.3); }, idx * 40);
-        })(i);
+      var n = Math.min(count, 4);
+      for (var i = 0; i < n; i++) {
+        this.playTone(freqs[i], 0.07, 'sine', 0.25, i * 0.04);
       }
     },
+
     tubeComplete: function () {
-      [523, 659, 784].forEach(function (f, i) {
-        setTimeout(function () { audio.playTone(f, 0.3, 'sine', 0.35); }, i * 50);
-      });
+      // C-E-G arpeggio — celebratory
+      var notes = [523, 659, 784];
+      for (var i = 0; i < notes.length; i++) {
+        this.playTone(notes[i], 0.3, 'sine', 0.3, i * 0.05);
+      }
     },
+
     win: function () {
-      [523, 659, 784, 1047].forEach(function (f, i) {
-        setTimeout(function () { audio.playTone(f, 0.5, 'sine', 0.4); }, i * 120);
-      });
+      // C-E-G-C fanfare — longer, louder, with rising gain
+      var notes = [523, 659, 784, 1047];
+      for (var i = 0; i < notes.length; i++) {
+        this.playTone(notes[i], 0.5, 'sine', 0.25 + i * 0.05, i * 0.12);
+      }
     },
+
     undo: function () {
-      this.playTone(440, 0.06, 'sine', 0.25);
-      setTimeout(function () { audio.playTone(330, 0.08, 'sine', 0.2); }, 40);
+      // Falling two-tone — reverse of place
+      this.playTone(440, 0.06, 'sine', 0.2, 0);
+      this.playTone(330, 0.08, 'sine', 0.15, 0.04);
     },
-    hint: function () { this.playTone(1047, 0.2, 'sine', 0.2); },
+
+    hint: function () {
+      // Two-note chime — more distinctive than single tone
+      this.playTone(1047, 0.15, 'sine', 0.15, 0);
+      this.playTone(1319, 0.2, 'sine', 0.12, 0.08);
+    },
   };
 
   // ============================================

--- a/apps/web-astro/public/sw.js
+++ b/apps/web-astro/public/sw.js
@@ -58,7 +58,7 @@ self.addEventListener('notificationclick', (event) => {
 });
 
 // Cache version - increment this on each deployment
-const CACHE_VERSION = 75;
+const CACHE_VERSION = 76;
 const CACHE_NAME = `weekly-arcade-v${CACHE_VERSION}`;
 
 // Core assets to pre-cache


### PR DESCRIPTION
## Summary
Audio engine rewritten per sound-design skill best practices.

### Changes
1. **Master gain node** — all oscillators route through `masterGain` for volume control
2. **iOS AudioContext resume** — `ctx.resume()` on suspended state (fixes silent audio on iOS Safari)
3. **AudioContext scheduling** — replaced all `setTimeout` with `ctx.currentTime + offset` (precise timing, works in background tabs)
4. **ADSR envelope** — 5ms attack peak (1.2x) then settle to sustain before exponential release
5. **`playRamp` method** — new utility for frequency-sliding tones
6. **Hint sound** — two-note chime (C6+E6) instead of single tone
7. **Win sound** — rising gain per note for crescendo effect
8. CACHE_VERSION 75 -> 76

### Before/After
| Sound | Before | After |
|-------|--------|-------|
| Place | setTimeout 2-tone | AudioContext scheduled, ADSR peak |
| Stack Transfer | setTimeout cascade | AudioContext scheduled cascade |
| Tube Complete | setTimeout arpeggio | AudioContext scheduled C-E-G |
| Win | setTimeout fanfare | AudioContext scheduled with crescendo |
| Hint | Single 1047Hz tone | Two-note C6+E6 chime |
| All | Direct to destination | Through masterGain node |
| iOS | No resume | ctx.resume() on init |

## Test plan
- [ ] Audio plays on first tap (desktop Chrome, Safari, Firefox)
- [ ] Audio plays on first tap (iOS Safari, Android Chrome)
- [ ] Mute toggle silences all sounds
- [ ] Each sound event triggers correctly (pickup, place, invalid, stack, complete, win, undo, hint)
- [ ] Multi-note sounds have clean timing (no glitches/overlap)
- [ ] Build passes

Generated with [Claude Code](https://claude.com/claude-code)