### PR TITLE
feat: Add GameLanding component — marketing section before gameplay

### DIFF
--- a/apps/web-astro/public/sw.js
+++ b/apps/web-astro/public/sw.js
@@ -58,7 +58,7 @@ self.addEventListener('notificationclick', (event) => {
 });
 
 // Cache version - increment this on each deployment
-const CACHE_VERSION = 88;
+const CACHE_VERSION = 89;
 const CACHE_NAME = `weekly-arcade-v${CACHE_VERSION}`;
 
 // Core assets to pre-cache

--- a/apps/web-astro/src/components/GameLanding.astro
+++ b/apps/web-astro/src/components/GameLanding.astro
@@ -47,7 +47,7 @@ const { gameName, icon, description, themeColor, features, howToPlay, screenshot
     <!-- Screenshot slot (optional) -->
     {screenshotSrc && (
       <div class="gl-screenshot">
-        <img src={screenshotSrc} alt={`${gameName} gameplay`} loading="lazy" width="400" height="250" />
+        <img src={screenshotSrc} alt={`${gameName} gameplay screenshot`} width="400" height="250" />
       </div>
     )}
 
@@ -60,8 +60,9 @@ const { gameName, icon, description, themeColor, features, howToPlay, screenshot
     )}
 
     <!-- CTA — always in first fold -->
-    <button class="gl-cta" id="glPlayBtn" aria-label={`Play ${gameName}`}>
-      ▶ Play Now
+    <button class="gl-cta" id="glPlayBtn" type="button" aria-label={`Play ${gameName}`}>
+      <svg class="gl-cta-icon" width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+      Play Now
     </button>
 
     <div class="gl-free-badge">Free · No Ads · No Download</div>
@@ -114,7 +115,7 @@ const { gameName, icon, description, themeColor, features, howToPlay, screenshot
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 20px;
+    gap: 24px; /* 3×8dp spacing rhythm */
   }
 
   /* Hero */
@@ -141,11 +142,11 @@ const { gameName, icon, description, themeColor, features, howToPlay, screenshot
   }
 
   .gl-desc {
-    font-size: 14px;
-    color: rgba(255,255,255,0.6);
+    font-size: 15px;
+    color: rgba(255,255,255,0.75); /* 4.5:1+ contrast on dark bg */
     margin: 0;
     max-width: 360px;
-    line-height: 1.5;
+    line-height: 1.6;
   }
 
   /* Features */
@@ -178,14 +179,14 @@ const { gameName, icon, description, themeColor, features, howToPlay, screenshot
   }
 
   .gl-feature-title {
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 700;
     color: #fff;
   }
 
   .gl-feature-desc {
-    font-size: 11px;
-    color: rgba(255,255,255,0.5);
+    font-size: 12px;
+    color: rgba(255,255,255,0.65); /* 3.5:1+ contrast */
   }
 
   /* Screenshot */
@@ -213,14 +214,14 @@ const { gameName, icon, description, themeColor, features, howToPlay, screenshot
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 1.2px;
-    color: rgba(255,255,255,0.4);
-    margin-bottom: 6px;
+    color: rgba(255,255,255,0.6); /* 3:1+ contrast */
+    margin-bottom: 8px;
   }
 
   .gl-how-text {
-    font-size: 13px;
-    color: rgba(255,255,255,0.6);
-    line-height: 1.5;
+    font-size: 14px;
+    color: rgba(255,255,255,0.7);
+    line-height: 1.6;
     margin: 0;
   }
 
@@ -248,14 +249,33 @@ const { gameName, icon, description, themeColor, features, howToPlay, screenshot
     box-shadow: 0 6px 28px color-mix(in srgb, var(--themeColor) 50%, transparent);
   }
 
+  .gl-cta:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 3px;
+  }
+
   .gl-cta:active {
     transform: scale(0.97);
   }
 
+  .gl-cta-icon {
+    display: inline-block;
+    vertical-align: -2px;
+    margin-right: 4px;
+  }
+
   .gl-free-badge {
-    font-size: 11px;
-    color: rgba(255,255,255,0.35);
+    font-size: 12px;
+    color: rgba(255,255,255,0.55); /* 3:1+ contrast */
     letter-spacing: 0.5px;
+  }
+
+  /* Reduced motion */
+  @media (prefers-reduced-motion: reduce) {
+    .gl-cta { transition: none; }
+    .gl-cta:hover { transform: none; }
+    .gl-cta:active { transform: none; }
+    .gl-landing { transition: none; }
   }
 
   /* When playing, hide landing and allow game to use full viewport */

--- a/apps/web-astro/src/components/GameLanding.astro
+++ b/apps/web-astro/src/components/GameLanding.astro
@@ -1,0 +1,302 @@
+---
+/**
+ * GameLanding — optional landing/marketing section shown above the game.
+ *
+ * Shows a hero with game name, description, features, and a prominent
+ * "Play Now" CTA. The CTA hides the landing and reveals the game.
+ *
+ * The CTA must always be visible in the first fold regardless of screen size.
+ */
+interface Props {
+  gameName: string;
+  icon?: string;
+  description: string;
+  themeColor: string;
+  features?: { icon: string; title: string; desc: string }[];
+  howToPlay?: string;
+  screenshotSrc?: string;
+}
+
+const { gameName, icon, description, themeColor, features, howToPlay, screenshotSrc } = Astro.props;
+---
+
+<section class="gl-landing" id="gameLanding">
+  <div class="gl-container">
+    <!-- Hero -->
+    <div class="gl-hero">
+      {icon && <div class="gl-icon">{icon}</div>}
+      <h2 class="gl-title">{gameName}</h2>
+      <p class="gl-desc">{description}</p>
+    </div>
+
+    <!-- Features (if provided) -->
+    {features && features.length > 0 && (
+      <div class="gl-features">
+        {features.map((f) => (
+          <div class="gl-feature">
+            <span class="gl-feature-icon">{f.icon}</span>
+            <div class="gl-feature-text">
+              <div class="gl-feature-title">{f.title}</div>
+              <div class="gl-feature-desc">{f.desc}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    )}
+
+    <!-- Screenshot slot (optional) -->
+    {screenshotSrc && (
+      <div class="gl-screenshot">
+        <img src={screenshotSrc} alt={`${gameName} gameplay`} loading="lazy" width="400" height="250" />
+      </div>
+    )}
+
+    <!-- How to Play (if provided) -->
+    {howToPlay && (
+      <div class="gl-how">
+        <div class="gl-how-label">How to Play</div>
+        <p class="gl-how-text">{howToPlay}</p>
+      </div>
+    )}
+
+    <!-- CTA — always in first fold -->
+    <button class="gl-cta" id="glPlayBtn" aria-label={`Play ${gameName}`}>
+      ▶ Play Now
+    </button>
+
+    <div class="gl-free-badge">Free · No Ads · No Download</div>
+  </div>
+</section>
+
+<script is:inline>
+(function() {
+  // If user has played before, skip landing and go straight to game
+  var played = localStorage.getItem('gl_played_' + document.body.dataset.gameId);
+  if (played) {
+    var landing = document.getElementById('gameLanding');
+    if (landing) landing.style.display = 'none';
+    document.body.classList.add('gl-playing');
+  }
+
+  var btn = document.getElementById('glPlayBtn');
+  if (btn) {
+    btn.addEventListener('click', function() {
+      var landing = document.getElementById('gameLanding');
+      if (landing) {
+        landing.style.opacity = '0';
+        landing.style.transform = 'translateY(-20px)';
+        setTimeout(function() {
+          landing.style.display = 'none';
+          document.body.classList.add('gl-playing');
+        }, 200);
+      }
+      // Remember for next visit
+      var gameId = document.body.dataset.gameId || '';
+      if (gameId) localStorage.setItem('gl_played_' + gameId, '1');
+    });
+  }
+})();
+</script>
+
+<style define:vars={{ themeColor }}>
+  .gl-landing {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: calc(100dvh - 62px);
+    padding: 20px 16px;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .gl-container {
+    max-width: 480px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+  }
+
+  /* Hero */
+  .gl-hero {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .gl-icon {
+    font-size: 56px;
+    line-height: 1;
+    filter: drop-shadow(0 4px 16px color-mix(in srgb, var(--themeColor) 30%, transparent));
+  }
+
+  .gl-title {
+    font-size: 32px;
+    font-weight: 900;
+    color: #fff;
+    margin: 0;
+    letter-spacing: -0.5px;
+  }
+
+  .gl-desc {
+    font-size: 14px;
+    color: rgba(255,255,255,0.6);
+    margin: 0;
+    max-width: 360px;
+    line-height: 1.5;
+  }
+
+  /* Features */
+  .gl-features {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+  }
+
+  .gl-feature {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    background: rgba(255,255,255,0.04);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 12px;
+  }
+
+  .gl-feature-icon {
+    font-size: 24px;
+    flex-shrink: 0;
+  }
+
+  .gl-feature-text {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .gl-feature-title {
+    font-size: 13px;
+    font-weight: 700;
+    color: #fff;
+  }
+
+  .gl-feature-desc {
+    font-size: 11px;
+    color: rgba(255,255,255,0.5);
+  }
+
+  /* Screenshot */
+  .gl-screenshot {
+    width: 100%;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid rgba(255,255,255,0.1);
+  }
+
+  .gl-screenshot img {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+
+  /* How to play */
+  .gl-how {
+    width: 100%;
+    text-align: center;
+  }
+
+  .gl-how-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: rgba(255,255,255,0.4);
+    margin-bottom: 6px;
+  }
+
+  .gl-how-text {
+    font-size: 13px;
+    color: rgba(255,255,255,0.6);
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  /* CTA Button — always visible in first fold */
+  .gl-cta {
+    width: 100%;
+    max-width: 320px;
+    padding: 16px 24px;
+    font-size: 18px;
+    font-weight: 800;
+    color: #fff;
+    background: var(--themeColor);
+    border: none;
+    border-radius: 14px;
+    cursor: pointer;
+    letter-spacing: 0.5px;
+    box-shadow: 0 4px 20px color-mix(in srgb, var(--themeColor) 40%, transparent);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .gl-cta:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 28px color-mix(in srgb, var(--themeColor) 50%, transparent);
+  }
+
+  .gl-cta:active {
+    transform: scale(0.97);
+  }
+
+  .gl-free-badge {
+    font-size: 11px;
+    color: rgba(255,255,255,0.35);
+    letter-spacing: 0.5px;
+  }
+
+  /* When playing, hide landing and allow game to use full viewport */
+  :global(body.gl-playing) .gl-landing {
+    display: none !important;
+  }
+
+  /* Game content hidden until playing */
+  :global(body:not(.gl-playing)) [data-nosnippet] {
+    display: none;
+  }
+
+  /* Allow scrolling for landing, lock for gameplay */
+  :global(body:not(.gl-playing)) {
+    overflow: auto !important;
+    overflow-x: hidden !important;
+    touch-action: auto !important;
+  }
+
+  /* Small screens — ensure CTA is always in first fold */
+  @media (max-height: 600px) {
+    .gl-landing {
+      min-height: auto;
+      padding: 12px 16px;
+    }
+
+    .gl-icon { font-size: 40px; }
+    .gl-title { font-size: 26px; }
+    .gl-features { display: none; }
+    .gl-screenshot { display: none; }
+    .gl-how { display: none; }
+
+    .gl-cta {
+      padding: 14px 20px;
+      font-size: 16px;
+    }
+  }
+
+  @media (max-height: 480px) {
+    .gl-desc { display: none; }
+    .gl-icon { font-size: 32px; }
+    .gl-title { font-size: 22px; }
+  }
+</style>

--- a/apps/web-astro/src/components/GameSEOContent.astro
+++ b/apps/web-astro/src/components/GameSEOContent.astro
@@ -100,7 +100,13 @@ const faqSchema = faq?.length ? JSON.stringify({
     {similarTo?.length && (
       <div class="seo-block">
         <h2>Games Like {gameName}</h2>
-        <p>If you enjoy {gameName}, you might also like: {similarTo.join(', ')}. {gameName} is available free on Weekly Arcade with no downloads required - <a href="/games/">browse all games</a>.</p>
+        <p>If you enjoy {gameName}, you might also like: {similarTo.map((name, i) => {
+          const slug = name.toLowerCase().replace(/\s+/g, '-');
+          const isInternal = ['wordle', '2048', 'snake', 'memory-match', 'solitaire-roguelite', 'fieldstone', 'coin-cascade', 'stack-tower', 'tiny-tycoon', 'voidbreak', 'lumble', 'chaos-kitchen', 'chess-3d', 'cricket-blitz', 'drift-legends', 'chroma-sort'].includes(slug);
+          return isInternal
+            ? <><a href={`/games/${slug}/`}>{name}</a>{i < similarTo.length - 1 ? ', ' : ''}</>
+            : <>{name}{i < similarTo.length - 1 ? ', ' : ''}</>;
+        })}. {gameName} is available free on Weekly Arcade — <a href="/games/">browse all games</a>.</p>
       </div>
     )}
   </section>

--- a/apps/web-astro/src/data/games/chroma-sort.json
+++ b/apps/web-astro/src/data/games/chroma-sort.json
@@ -4,7 +4,7 @@
   "icon": "🍡",
   "title": "Chroma Sort | Weekly Arcade - Free Daily Color Sorting Puzzle",
   "description": "Sort colored balls into matching tubes in this satisfying, ad-free puzzle game. Play the daily challenge, climb the leaderboard, or take on 100+ endless levels.",
-  "keywords": "chroma sort, color sort puzzle, ball sort game, daily puzzle, sorting game no ads, free puzzle game, browser puzzle, color sorting game",
+  "keywords": "chroma sort, color sort puzzle online free, ball sort game no ads, daily sorting puzzle, sorting game browser, free color sorting game, tube sort puzzle, ball sort puzzle online, sort puzzle no download",
   "url": "/games/chroma-sort/",
   "themeColor": "#6C3DE8",
   "accentColor": "#6C3DE8",
@@ -20,7 +20,7 @@
   ],
   "similarTo": ["Water Sort Puzzle", "Ball Sort Puzzle", "Wordle", "2048", "Sudoku"],
   "howToPlay": "Tap a tube to pick up the top ball, then tap another tube to place it. A ball can only be placed on a matching color or an empty tube. Sort all balls so each tube contains only one color to win. Use Undo (free and unlimited) and Hints (3 per day) to help you solve tricky puzzles.",
-  "aboutGame": "Chroma Sort is a free daily color sorting puzzle game. Each day brings three new puzzles at Easy, Medium, and Hard difficulty. Sort colored balls into matching tubes using strategic thinking and planning. The game features satisfying ASMR-style audio feedback, a Wordle-style shareable result card, global leaderboards, and an Endless Mode with 100+ procedurally generated levels. No ads, no downloads, no paywalls - just pure puzzle satisfaction.",
+  "aboutGame": "Chroma Sort is a free online color sorting puzzle game you can play directly in your browser with no downloads or ads. Every day, three new Daily Challenge puzzles are generated at Easy (4 colors, 6 tubes), Medium (6 colors, 8 tubes), and Hard (8 colors, 11 tubes) difficulty — the same puzzles for every player worldwide, so you can compete fairly on the global leaderboard. Unlike other ball sort puzzle apps that bombard you with video ads and lock undo behind paywalls, Chroma Sort gives you completely free unlimited undo, 3 daily hints, and an earned Extra Tube power-up. The game features satisfying ASMR-style synthesized audio, a Wordle-style emoji share card to post your daily result, and an Endless Mode with 100+ procedurally generated levels that ramp from 3 colors all the way to 10. Whether you call it color sort, ball sort, tube sort, or water sort — if you love sorting puzzles, Chroma Sort is the ad-free browser version you have been looking for.",
   "faq": [
     {
       "q": "Is Chroma Sort free to play?",

--- a/apps/web-astro/src/layouts/GameLayout.astro
+++ b/apps/web-astro/src/layouts/GameLayout.astro
@@ -91,6 +91,14 @@ const {
 
   <GameHeader title={gameName} icon={icon} />
 
+  <!-- Set game ID on body for landing section localStorage key -->
+  <script is:inline define:vars={{ gameId }}>
+    document.body.dataset.gameId = gameId;
+  </script>
+
+  <!-- Optional landing/marketing section (outside nosnippet for SEO indexing) -->
+  <slot name="landing" />
+
   <!-- Game-specific body content (nosnippet prevents Google indexing HUD/UI text) -->
   <div data-nosnippet>
     <slot />

--- a/apps/web-astro/src/pages/games/chroma-sort.astro
+++ b/apps/web-astro/src/pages/games/chroma-sort.astro
@@ -1,6 +1,13 @@
 ---
 import GameLayout from '../../layouts/GameLayout.astro';
+import GameLanding from '../../components/GameLanding.astro';
 import gameData from '../../data/games/chroma-sort.json';
+
+const features = [
+  { icon: '📅', title: 'Daily Challenge', desc: 'New puzzle every day at Easy, Medium, and Hard' },
+  { icon: '🚫', title: 'Zero Ads', desc: 'Free unlimited undo, free hints — no ads ever' },
+  { icon: '🏆', title: 'Global Leaderboard', desc: 'Compete on time + moves, share your result' },
+];
 ---
 
 <GameLayout
@@ -24,6 +31,18 @@ import gameData from '../../data/games/chroma-sort.json';
 >
   <Fragment slot="head">
     <link rel="stylesheet" href="/games/chroma-sort/styles.css">
+  </Fragment>
+
+  <Fragment slot="landing">
+    <GameLanding
+      gameName={gameData.name}
+      icon={gameData.icon}
+      description="Sort colored balls into matching tubes in this satisfying puzzle game. Play the daily challenge, climb the leaderboard, or take on 100+ endless levels."
+      themeColor={gameData.themeColor}
+      features={features}
+      howToPlay={gameData.howToPlay}
+      screenshotSrc="/images/thumbnails/chroma-sort.svg"
+    />
   </Fragment>
 
   <div id="chroma-sort-app"></div>


### PR DESCRIPTION
## Summary
New reusable GameLanding component that shows a marketing/SEO section before gameplay starts. First visitor sees hero + features + CTA, then plays. Return visitors skip straight to game.

### How it works
1. New `slot="landing"` in GameLayout (outside `data-nosnippet` — indexable by Google)
2. GameLanding.astro renders hero, features, screenshot, how-to-play, CTA
3. "Play Now" CTA hides landing, reveals game, saves to localStorage
4. Return visitors skip landing automatically

### CTA always in first fold
- Short screens (<600px): features/screenshot/how-to-play hidden
- Very short (<480px): description hidden too
- Only icon + title + CTA remain — guaranteed above fold on any device

### Applied to Chroma Sort
- 3 feature cards (Daily Challenge, Zero Ads, Leaderboard)
- How to Play section
- SVG thumbnail as screenshot
- Purple themed CTA with glow

### SEO Impact
- Landing content is outside `data-nosnippet` — fully indexable
- Features, description, how-to-play all add keyword-rich text
- Improves bounce rate (context before gameplay)

## Test plan
- [ ] First visit: landing shows, CTA visible above fold
- [ ] Tap Play Now: landing hides, game appears
- [ ] Second visit: game loads directly (no landing)
- [ ] Clear localStorage: landing shows again
- [ ] Small screen (320px, 480px height): CTA still visible
- [ ] SEO: view-source shows landing text (not hidden by JS)
- [ ] Build passes

Generated with [Claude Code](https://claude.com/claude-code)