### PR TITLE
fix(bir-glider): Require both distance AND task goal for level completion

### DIFF
--- a/apps/web-astro/public/games/bir-glider/game.js
+++ b/apps/web-astro/public/games/bir-glider/game.js
@@ -2606,8 +2606,10 @@ function gameLoop(ts) {
   updatePhysics(dt);
   checkCollisions();
   checkGoals();
-  // Level completion check
-  if (gameMode === 'levels' && currentLevel && !levelCompleteShown && distance >= currentLevel.distGoal) {
+  // Level completion check — require BOTH distance goal AND task goal
+  if (gameMode === 'levels' && currentLevel && !levelCompleteShown
+      && distance >= currentLevel.distGoal
+      && (!currentLevel.goal || currentLevel.goal.check())) {
     levelCompleteShown = true;
     completeLevelAction();
     return;
@@ -2625,7 +2627,14 @@ function gameLoop(ts) {
 // ---- HUD ----
 function updateHUD() {
   if (gameMode === 'levels' && currentLevel) {
-    document.getElementById('hudDistance').innerHTML = Math.floor(distance) + ' / ' + currentLevel.distGoal + ' <span>m</span>';
+    const distMet = distance >= currentLevel.distGoal;
+    const goalMet = !currentLevel.goal || currentLevel.goal.check();
+    if (distMet && !goalMet) {
+      // Distance done but task pending — show checkmark on distance + highlight goal
+      document.getElementById('hudDistance').innerHTML = '✓ ' + currentLevel.distGoal + ' <span>m</span>';
+    } else {
+      document.getElementById('hudDistance').innerHTML = Math.floor(distance) + ' / ' + currentLevel.distGoal + ' <span>m</span>';
+    }
     document.getElementById('hudBest').textContent = currentLevel.name;
   } else {
     document.getElementById('hudDistance').innerHTML = Math.floor(distance) + ' <span>m</span>';
@@ -2685,10 +2694,15 @@ function renderGoals() {
   const nextGoal = goals.find(g => !goalProgress[g.id]);
   if (nextGoal) {
     pinned.textContent = '★ ' + nextGoal.text;
+    // Pulse when distance is done but goal is pending — draw player's attention
+    const distMet = gameMode === 'levels' && currentLevel && distance >= currentLevel.distGoal;
+    pinned.classList.toggle('goal-urgent', !!distMet);
   } else if (goals.length > 0) {
     pinned.textContent = '✓ All goals complete!';
+    pinned.classList.remove('goal-urgent');
   } else {
     pinned.textContent = '';
+    pinned.classList.remove('goal-urgent');
   }
 }
 

--- a/apps/web-astro/public/games/bir-glider/styles.css
+++ b/apps/web-astro/public/games/bir-glider/styles.css
@@ -125,6 +125,20 @@
   color: rgba(255,255,255,0.55);
   text-shadow: 0 1px 4px rgba(0,0,0,0.5);
   white-space: nowrap;
+  transition: color 0.3s, transform 0.3s;
+}
+
+/* Urgent: distance met but goal not — pulse to draw attention */
+.hud-goal-pinned.goal-urgent {
+  color: #ffd700;
+  font-weight: 700;
+  font-size: 0.9rem;
+  animation: goalPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes goalPulse {
+  0%, 100% { transform: translateX(-50%) scale(1); opacity: 1; }
+  50% { transform: translateX(-50%) scale(1.08); opacity: 0.8; }
 }
 
 /* Altitude bar */

--- a/apps/web-astro/public/sw.js
+++ b/apps/web-astro/public/sw.js
@@ -58,7 +58,7 @@ self.addEventListener('notificationclick', (event) => {
 });
 
 // Cache version - increment this on each deployment
-const CACHE_VERSION = 121;
+const CACHE_VERSION = 122;
 const CACHE_NAME = `weekly-arcade-v${CACHE_VERSION}`;
 
 // Core assets to pre-cache


### PR DESCRIPTION
## Summary
- Level completion now requires **both** distance goal AND task goal (e.g. "Catch a thermal", "Collect 5 flags")
- Previously, reaching the distance alone would complete the level, ignoring the task
- When distance is met but task is pending: HUD shows ✓ on distance, pinned goal pulses gold

## Test plan
- [ ] Play Level 2 (Rising Wind, distGoal=400, goal="Catch a thermal") — fly 400m without catching a thermal, verify level does NOT complete
- [ ] Catch a thermal after 400m — verify level completes
- [ ] Verify pinned goal text turns gold and pulses when distance is met but task is pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)